### PR TITLE
Dynamic fetch bug fix in CWBVH traversal kernel

### DIFF
--- a/src/TraversalKernelCWBVH.cu
+++ b/src/TraversalKernelCWBVH.cu
@@ -57,7 +57,7 @@ __global__ void rtTraceCWBVHDynamicFetch(
 	{
 		int& rayBase = nextRayArray[threadIdx.y];
 
-		bool				terminated = stackPtr == 0 && nodeGroup.y <= 0x00FFFFFF;
+		bool				terminated = stackPtr == 0 && nodeGroup.y <= 0x00FFFFFF && triangleGroup.y == 0;
 		const unsigned int	maskTerminated = __ballot_sync(__activemask(), terminated);
 		const int			numTerminated = __popc(maskTerminated);
 		const int			idxTerminated = __popc(maskTerminated & ((1u << threadIdx.x) - 1));

--- a/src/helper_math.h
+++ b/src/helper_math.h
@@ -1773,7 +1773,9 @@ __device__ __host__ inline void SHVectorRGB3::addIncomingRadiance(const float3& 
 	*this += SHVector3::basisFunction(worldSpaceDirection) * (incomingRadiance * weight);
 }
 
+#ifdef _WIN32
 __align__(16)
+#endif
 struct GatheredLightSample
 {
 	SHVector2 SHVector;


### PR DESCRIPTION
Fixed a tricky bug that was appearing on a few rays when using dynamic fetch in the CWBVH traversal kernel. When a ray is interrupted due to dynamic fetch after computing the intersection of boxes but before pushing any triangles on the stack, the termination condition is met without the ray writing to the output buffer causing a result of 0. Also fixed some GNU compiler warnings.